### PR TITLE
Added numpy to the installed packages.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.10-bullseye
 
 # Install required libraries
 RUN apt-get update
-RUN apt-get install -y wget gzip git libgsl-dev libcairo2-dev ; apt-get clean
+RUN apt-get install -y wget gzip git libgsl-dev libcairo2-dev python3-numpy; apt-get clean
 
 # Install ephemeris software
 WORKDIR /


### PR DESCRIPTION
dataFetch.py was failing because numpy was not installed. I'm not sure how it was ever working before, but I added it to the Dockerfile and it now builds and runs. I'm guessing something changed in the base image.