### PR TITLE
add parameter 'dso_names_openclusters'

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The following settings can be included in a `StarCharter` configuration file:
 * `dso_mag_min` - Only show deep-sky objects down to this faintest magnitude
 * `dso_mags` - Boolean (0 or 1) indicating whether we label the magnitudes of deep-sky objects
 * `dso_names` - Boolean (0 or 1) indicating whether we label the names of deep-sky objects
+* `dso_names_openclusters` - Boolean (0 or 1) indicating whether we label the names of openclusters
 * `dso_nebula_col` - Colour to use when drawing nebulae
 * `dso_outline_col` - Colour to use when drawing the outline of deep-sky objects
 * `dso_point_size_scaling` - Size scaling of deep-sky object symbols. Default 1.

--- a/examples/dso_planner.sch
+++ b/examples/dso_planner.sch
@@ -1,0 +1,91 @@
+# Demonstration of creating quadrant views of the night sky with interesting
+# DSOs highlighted (i.e. those brighter than a threshold magnitude, and not open
+# clusters).
+
+DEFAULTS
+coords=alt_az
+horizon_latitude=56.30
+horizon_longitude=-3.71
+# date -d 'tomorrow 00:00' +%s | awk '{printf "%.1f\n", $1/86400 + 2440587.5}'
+julian_date=2460942.5 # Wed 24 Sep 00:00:00 BST 2025
+
+# A4 page
+angular_width=110
+width=29.7
+aspect=0.707
+
+# show the horizon but no other curves
+show_horizon=1
+cardinals=1
+grid_coords=ra_dec
+show_grid_lines=1
+plot_galactic_plane=0
+plot_ecliptic=0
+plot_equator=0
+plot_galaxy_map=0
+
+# stars, show them but don't label them
+mag_min=9.1
+star_label_mag_min=0
+
+# don't show solar system objects, so we can reuse every year
+show_solar_system=0
+
+# show all DSOs except open clusters
+# (uses colours that are visible with a red light)
+#
+# Unfortunately this also shows things that turned out to
+# not be DSOs, e.g. NGC 7748, so those need a DB update.
+#
+# Note that _mag_min values are exclusive.
+plot_dso=1
+#dso_display_style=fuzzy
+dso_mag_min=12.1
+dso_label_mag_min=11.1
+dso_cluster_col=0.5,0.5,0.5
+dso_galaxy_col=0,0,0
+dso_nebula_col=0.8,0.8,0.8
+dso_names_openclusters=0
+# if we don't force render, then almost nothing gets shown
+must_label_all_dsos=1
+
+# minimise constellation impact
+constellation_boundaries=0
+constellation_names=0
+constellation_stick_design=simplified
+constellation_stick_col=0.5,0.5,0.5
+constellation_sticks_line_width=0.7
+
+# turn off all legends
+copyright=
+magnitude_key=0
+dso_symbol_key=0
+
+# draw the zenith
+text=alt_az,90,0,0,0,1,1,0,0,0,1,+
+
+# turn off arbitrary limits, so we use magnitudes exclusively
+maximum_star_count=10000
+maximum_star_label_count=10000
+maximum_dso_count=10000
+maximum_dso_label_count=10000
+
+CHART
+az_central=0
+alt_central=60
+output_filename=output/dso_planner_N.pdf
+
+CHART
+az_central=90
+alt_central=60
+output_filename=output/dso_planner_E.pdf
+
+CHART
+az_central=180
+alt_central=60
+output_filename=output/dso_planner_S.pdf
+
+CHART
+az_central=270
+alt_central=60
+output_filename=output/dso_planner_W.pdf

--- a/src/astroGraphics/deepSky.c
+++ b/src/astroGraphics/deepSky.c
@@ -710,17 +710,19 @@ void plot_deep_sky_objects(chart_config *s, cairo_page *page, int messier_only) 
 
             // Write a text label for this object
             const int show_name = s->dso_names;
+            const int show_name_openclusters = s->dso_names_openclusters;
             const int show_mag = s->dso_mags && (mag < 40);
             const int multiple_labels = show_name && show_mag;
+            const int dso_type_filter = !is_open_cluster || show_name_openclusters;
 
-            if (show_name) {
+            if (show_name && dso_type_filter) {
                 chart_label_buffer(page, s, s->dso_label_col, object_name,
                                    possible_positions, possible_position_count,
                                    multiple_labels, 0, 1.2 * s->label_font_size_scaling,
                                    0, 0, 0, priority);
                 label_counter++;
             }
-            if (show_mag) {
+            if (show_mag && dso_type_filter) {
                 snprintf(temp_err_string, FNAME_LENGTH, "%.1f", mag);
                 chart_label_buffer(page, s, s->dso_label_col, temp_err_string,
                                    possible_positions, possible_position_count,

--- a/src/settings/chart_config.c
+++ b/src/settings/chart_config.c
@@ -134,6 +134,7 @@ void default_config(chart_config *i) {
     i->dso_style = SW_DSO_STYLE_COLOURED;
     i->dso_label_mag_min = 9999;
     i->dso_names = 1;
+    i->dso_names_openclusters = 1;
     i->dso_mags = 0;
     i->dso_mag_min = 14;
     i->must_label_all_dsos = 0;

--- a/src/settings/chart_config.h
+++ b/src/settings/chart_config.h
@@ -367,6 +367,9 @@ typedef struct chart_config {
     //! Boolean indicating whether we label the names of NGC objects
     int dso_names;
 
+    //! Boolean indicating whether we label the names of open clusters
+    int dso_names_openclusters;
+
     //! Boolean indicating whether we label the magnitudes of NGC objects
     int dso_mags;
 

--- a/src/settings/read_config.c
+++ b/src/settings/read_config.c
@@ -938,6 +938,11 @@ int process_configuration_file_line(char *line, const char *filename, const int 
         x->dso_names = (int) key_val_num;
         x->dso_names_is_set = 1;
         return 0;
+    } else if (strcmp(key, "dso_names_openclusters") == 0) {
+        //! dso_names_openclusters - Boolean (0 or 1) indicating whether we label the names of openclusters
+        CHECK_VALUE_NUMERIC("dso_names_openclusters")
+        x->dso_names_openclusters = (int) key_val_num;
+        return 0;
     } else if (strcmp(key, "dso_mags") == 0) {
         //! dso_mags - Boolean (0 or 1) indicating whether we label the magnitudes of deep sky objects
         CHECK_VALUE_NUMERIC("dso_mags")


### PR DESCRIPTION
and an example script to produce DSO quadrants (with open clusters labels hidden, demonstrating the feature).

Partial implementation of #23 doing just the bit I wanted.